### PR TITLE
Feature memdb hash map

### DIFF
--- a/node_modules/helpers/modules/hashing/index.js
+++ b/node_modules/helpers/modules/hashing/index.js
@@ -1,4 +1,4 @@
-function hash(input) {
+function hashString(input) {
     let hashKey = 0;
 
     for(const letters of input) {
@@ -10,4 +10,4 @@ function hash(input) {
     return hashKey.toString();
 }
 
-module.exports = { hash };
+module.exports = { hashString };

--- a/node_modules/helpers/modules/memdb/hash.js
+++ b/node_modules/helpers/modules/memdb/hash.js
@@ -1,0 +1,13 @@
+function hash(input) {
+    let hashKey = 0;
+
+    for(const letters of input) {
+        hashKey += letters.charCodeAt(0);
+    }
+
+    hashKey = hashKey*32%50000;
+
+    return hashKey.toString();
+}
+
+module.exports = { hash };

--- a/node_modules/helpers/modules/memdb/index.js
+++ b/node_modules/helpers/modules/memdb/index.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 const { hash } = require('./hash.js');
-const { error } = require('console');
 let cachedb = {};
 
 function write(filename, data) {

--- a/node_modules/helpers/modules/memdb/index.js
+++ b/node_modules/helpers/modules/memdb/index.js
@@ -34,7 +34,7 @@ function read(filename) {
 function findInHMap(hashProperty, storageName) {
     const hashKey = hashString(hashProperty);
 
-    return mapdb[storageName][hashKey] ? mapdb[storageName][hashKey] : -1;
+    return mapdb[storageName][hashKey] ? mapdb[storageName][hashKey] : -0;
 }
 
 function createHMap(hashProperty, storageName) {
@@ -43,11 +43,8 @@ function createHMap(hashProperty, storageName) {
     for(let index = 0; index < cachedb[storageName].length; index++) {
         const hashKey = hashString(cachedb[storageName][index][hashProperty]);
 
-        if(!mapdb[storageName][hashKey]) {
-            mapdb[storageName][hashKey] = [index];
-        } else {
-            mapdb[storageName][hashKey].push(index);
-        }
+        mapdb[storageName][hashKey] ??= index;
+        if (mapdb[storageName][hashKey] !== index) mapdb[storageName][hashKey] = index;
     }
 }
 

--- a/node_modules/helpers/modules/memdb/index.js
+++ b/node_modules/helpers/modules/memdb/index.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+const { hash } = require('./hash.js');
+const { error } = require('console');
 let cachedb = {};
 
 function write(filename, data) {
@@ -29,10 +31,44 @@ function read(filename) {
     }
 }
 
+function findInHMap(input, storageName) {
+    const index = hash(input);
+
+    if(!cachedb[storageName][index]) {
+        throw new Error('Object is not found.');
+    }
+
+    return cachedb[storageName][index];  
+}
+
+function addInHMap(input, storageName, data) {
+    const index = hash(input);
+
+    if(cachedb[storageName] == null) {
+        cachedb[storageName] = {};
+    }
+
+    if(cachedb[storageName][index] == null) {
+        cachedb[storageName][index] = [];
+    }
+
+    for(const objects of cachedb[storageName][index]) {
+        if(objects == data) { 
+            throw new Error('Object is already in the hashmap.');
+        }
+    }
+
+    cachedb[storageName][index].push(data);
+}
+
 module.exports = {
     memdb: {
         write: write,
         read: read,
-        cache: cachedb
+        cache: cachedb,
+        map: {
+            check: findInHMap,
+            add: addInHMap
+        }
     }
 };

--- a/node_modules/helpers/modules/memdb/index.js
+++ b/node_modules/helpers/modules/memdb/index.js
@@ -34,7 +34,7 @@ function read(filename) {
 function findInHMap(hashProperty, storageName) {
     const hashKey = hashString(hashProperty);
 
-    return mapdb[storageName][hashKey] ? mapdb[storageName][hashKey] : -0;
+    return mapdb[storageName][hashKey] ? mapdb[storageName][hashKey] : false;
 }
 
 function createHMap(hashProperty, storageName) {

--- a/node_modules/helpers/modules/memdb/index.js
+++ b/node_modules/helpers/modules/memdb/index.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-const { hash } = require('./hash.js');
+const { hashString } = require('helpers/modules/hashing');
 let cachedb = {};
+let mapdb = {};
 
 function write(filename, data) {
     const jsonString = JSON.stringify(data, null, 2);
@@ -30,34 +31,24 @@ function read(filename) {
     }
 }
 
-function findInHMap(input, storageName) {
-    const index = hash(input);
+function findInHMap(hashProperty, storageName) {
+    const hashKey = hashString(hashProperty);
 
-    if(!cachedb[storageName][index]) {
-        throw new Error('Object is not found.');
-    }
-
-    return cachedb[storageName][index];  
+    return mapdb[storageName][hashKey] ? mapdb[storageName][hashKey] : -1;
 }
 
-function addInHMap(input, storageName, data) {
-    const index = hash(input);
+function createHMap(hashProperty, storageName) {
+    if(!mapdb[storageName]) mapdb[storageName] = {};
 
-    if(cachedb[storageName] == null) {
-        cachedb[storageName] = {};
-    }
+    for(let index = 0; index < cachedb[storageName].length; index++) {
+        const hashKey = hashString(cachedb[storageName][index][hashProperty]);
 
-    if(cachedb[storageName][index] == null) {
-        cachedb[storageName][index] = [];
-    }
-
-    for(const objects of cachedb[storageName][index]) {
-        if(objects == data) { 
-            throw new Error('Object is already in the hashmap.');
+        if(!mapdb[storageName][hashKey]) {
+            mapdb[storageName][hashKey] = [index];
+        } else {
+            mapdb[storageName][hashKey].push(index);
         }
     }
-
-    cachedb[storageName][index].push(data);
 }
 
 module.exports = {
@@ -65,9 +56,9 @@ module.exports = {
         write: write,
         read: read,
         cache: cachedb,
-        map: {
-            check: findInHMap,
-            add: addInHMap
+        hash: {
+            find: findInHMap,
+            map: createHMap
         }
     }
 };


### PR DESCRIPTION
# Feature memdb hash map

Implemented a general purpose hash map in ```memdb``` for efficiently storing and searching through large containers.

# Convention
Storage containers that will use the general purpose hash map will be stored into their respective files directly and loaded into the cache as hash maps so the program doesn't waste time on initialization to convert the lists into hashmaps.

# Insights of the code
```hash.js``` consists of the  hashing function of the table.
```memdb/index.js``` contains 2 new functions:

- ```addInHMap```, which expects 3 inputs: an input string for the hashing function, which can be any type of input(message, user id, etc.), but the whole container must respect the chosen input type, the name of the storage container, and the new data that is requested to be added in the storage through the hash map. To prevent collisions, objects with the same hash key will be stored in the respective key as a list. The function also has a built-in feature to check if the object already exists so it doesn't get added once more.
- ```findInHMap```, which expects 2 inputs: the input string for the hashing function(same principles as the input for the addition function), and the name of the storage container. Since the objects in different containers could have different structures, the function will return the list at the hash key index, and in case of collisions,  the program would need to iterate through the list to find the requested object. 

# Useful docs
[Hash table](https://en.wikipedia.org/wiki/Hash_table#Overview)